### PR TITLE
#3 - PaymentConfig 하위 내용 주석 처리

### DIFF
--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/config/PaymentConfig.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/config/PaymentConfig.java
@@ -6,8 +6,9 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class PaymentConfig {
 
-    @Value("${pgmodule.app-id}")
-    private String apiKey;
-    @Value("${pgmodule.secret-key}")
-    private String apiSecret;
+//    @Value("${pgmodule.app-id}")
+//    private String apiKey;
+//    @Value("${pgmodule.secret-key}")
+//    private String apiSecret;
+
 }


### PR DESCRIPTION
의존성 주입 오류 발생을 해결하기 위한 주석 처리(임시방편)
- 결제 기능이 구현되어 있지 않기 때문에 발생하는 에러로 예상됨.