### PR TITLE
[feat -> Dev/fe] 회원 유형에 따라 로그인 로직 수정

### DIFF
--- a/client/src/Pages/Login.jsx
+++ b/client/src/Pages/Login.jsx
@@ -282,10 +282,10 @@ export default function Login() {
   });
   const [errorMessageContent, setErrorMessageContent] = useState();
   const [checked, setChecked] = useState(false);
-  const [isLoginTypeUser, setIsLoginTypeUser] = useState(true);
+  const [isLoginTypeUser, setIsLoginTypeUser] = useState("USER");
   const emailInputRef = useRef();
   const passwordInputRef = useRef();
-  const data = { email: email, password: password };
+  const data = { email: email, password: password, role: isLoginTypeUser };
   const navigate = useNavigate();
 
   const { isLogin, setIsLogin } = useIsLoginStore((state) => state);
@@ -299,7 +299,11 @@ export default function Login() {
   };
 
   const handleLoginType = () => {
-    setIsLoginTypeUser(!isLoginTypeUser);
+    if (isLoginTypeUser === "USER") {
+      setIsLoginTypeUser("PERFORMER");
+    } else {
+      setIsLoginTypeUser("USER");
+    }
   };
 
   const handlePasswordInputType = () => {
@@ -387,11 +391,17 @@ export default function Login() {
           </button>
         </SelectLoginTypeTab>
         <LoginContainer
-          color={isLoginTypeUser ? primary.primary100 : secondary.secondary300}
+          color={
+            isLoginTypeUser === "USER"
+              ? primary.primary100
+              : secondary.secondary300
+          }
         >
           <div className="input-container">
             <InputLabel
-              fontColor={isLoginTypeUser ? "white" : secondary.secondary700}
+              fontColor={
+                isLoginTypeUser === "USER" ? "white" : secondary.secondary700
+              }
             >
               이메일
             </InputLabel>
@@ -411,7 +421,9 @@ export default function Login() {
           </div>
           <div className="input-container">
             <InputLabel
-              fontColor={isLoginTypeUser ? "white" : secondary.secondary700}
+              fontColor={
+                isLoginTypeUser === "USER" ? "white" : secondary.secondary700
+              }
             >
               비밀번호
             </InputLabel>
@@ -438,9 +450,13 @@ export default function Login() {
             </div>
             <div className="keep-login-container">
               <KeepLoginCheckbox
-                borderColor={isLoginTypeUser ? "white" : secondary.secondary700}
+                borderColor={
+                  isLoginTypeUser === "USER" ? "white" : secondary.secondary700
+                }
                 color={
-                  isLoginTypeUser ? primary.primary300 : secondary.secondary500
+                  isLoginTypeUser === "USER"
+                    ? primary.primary300
+                    : secondary.secondary500
                 }
                 checked={checked}
                 type="checkbox"
@@ -448,7 +464,9 @@ export default function Login() {
               />
               <KeepLoginCheckboxLabel
                 id="keepLogin"
-                fontColor={isLoginTypeUser ? "white" : secondary.secondary700}
+                fontColor={
+                  isLoginTypeUser === "USER" ? "white" : secondary.secondary700
+                }
               >
                 로그인 유지
               </KeepLoginCheckboxLabel>
@@ -462,11 +480,15 @@ export default function Login() {
           <LoginButton
             onClick={handleLogin}
             color={
-              isLoginTypeUser ? primary.primary300 : secondary.secondary500
+              isLoginTypeUser === "USER"
+                ? primary.primary300
+                : secondary.secondary500
             }
             fontColor={"white"}
             hoverColor={
-              isLoginTypeUser ? secondary.secondary500 : primary.primary300
+              isLoginTypeUser === "USER"
+                ? secondary.secondary500
+                : primary.primary300
             }
           >
             로그인


### PR DESCRIPTION
## 도입 배경 
로그인 api가 하나로 통합되어있어 회원 유형에 따라 로그인을 분리해야 할 필요성을 느낌

## 주요 변화
*  로그인 폼을 클릭할 때마다 isLoginTypeUser state의 값이 USER, PERFORMER로 번갈아가며 바뀜
* 기존 로그인시 보내던 email, password에 더해 isLoginTypeUser를 value로 갖는 role을 추가