### PR TITLE
[Feat -> Dev/fe] ADMIN 페이지 추가

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -36,6 +36,9 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "react";
 import axios from "axios";
+import { AdminEntry } from "./Pages/Admin/AdminEntry.jsx";
+import { AdminMain } from "./Pages/Admin/AdminMain.jsx";
+import { useLocation } from "react-router-dom";
 
 const queryClient = new QueryClient();
 
@@ -44,7 +47,7 @@ function App() {
   const accessToken = localStorage.getItem("accessToken");
   const refreshToken = localStorage.getItem("refreshToken");
 
-  // console.log(setUserInfo);
+  const { pathname } = useLocation();
 
   useEffect(() => {
     if (refreshToken) {
@@ -72,7 +75,7 @@ function App() {
     <>
       <QueryClientProvider client={queryClient}>
         <ReactQueryDevtools initialIsOpen={false} />
-        <Header />
+        {pathname.includes("/admin") ? "" : <Header />}
         <Routes>
           <Route path="/" element={<Home />}></Route>
 
@@ -136,9 +139,12 @@ function App() {
           <Route path="/board/review/create" element={<BoardCreate />}></Route>
           <Route path="/board/review/:id" element={<Board />}></Route>
           <Route path="/board/review/:id/edit" element={<BoardEdit />}></Route>
+          {/* admin */}
+          <Route path="/admin" element={<AdminEntry />}></Route>
+          <Route path="/admin/main" element={<AdminMain />}></Route>
           <Route path="*" element={<NotFound />}></Route>
         </Routes>
-        <Footer />
+        {pathname.includes("/admin") ? "" : <Footer />}
       </QueryClientProvider>
     </>
   );

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,6 +23,7 @@ import RequestBoardList from "./Pages/Boards/BoardType/RequestBoardList.jsx";
 import AdvertiseBoardList from "./Pages/Boards/BoardType/AdvertiseBoardList.jsx";
 import ReviewBoardList from "./Pages/Boards/BoardType/ReviewBoardList.jsx";
 import Token from "./Pages/Token.jsx";
+import { AdminLogin } from "./Pages/AdminLogin.jsx";
 
 import Header from "./Components/Header.jsx";
 import Footer from "./Components/Footer.jsx";
@@ -140,6 +141,7 @@ function App() {
           <Route path="/board/review/:id" element={<Board />}></Route>
           <Route path="/board/review/:id/edit" element={<BoardEdit />}></Route>
           {/* admin */}
+          <Route path="/login/admin" element={<AdminLogin />}></Route>
           <Route path="/admin" element={<AdminEntry />}></Route>
           <Route path="/admin/main" element={<AdminMain />}></Route>
           <Route path="*" element={<NotFound />}></Route>

--- a/client/src/Components/Admin/List.jsx
+++ b/client/src/Components/Admin/List.jsx
@@ -218,7 +218,9 @@ const ListCommentsBody = ({ data, index, handlers, queryKey }) => {
     mutationKey: ["deleteCommentAdmin", data.id],
     mutationFn: remove({ id: data.id }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [queryKey] });
+      queryClient.invalidateQueries({
+        queryKey: "FetchComments",
+      });
     },
     onError: (err) => {
       console.log(err);
@@ -251,7 +253,9 @@ const ListDeletedBody = ({ data, index, handlers, queryKey }) => {
     mutationKey: ["restoreCommentAdmin", data.id],
     mutationFn: restore({ id: data.id }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [queryKey] });
+      queryClient.invalidateQueries({
+        queryKey: "FetchComments",
+      });
     },
     onError: (err) => {
       console.log(err);

--- a/client/src/Components/Admin/List.jsx
+++ b/client/src/Components/Admin/List.jsx
@@ -133,12 +133,20 @@ const InputModal = ({ message, setMessage, handlers, modalStates }) => {
           id="message"
         />
         <div className="button_container">
-          <button onClick={sendReqHandler(purpose)}>send</button>
+          <button
+            onClick={() => {
+              sendReqHandler(purpose);
+              document.querySelector("body").classList.remove("modal_open");
+            }}
+          >
+            send
+          </button>
           <button
             onClick={(e) => {
               e.preventDefault();
               setModalStates({ open: false, purpose: "" });
               setMessage("");
+              document.querySelector("body").classList.remove("modal_open");
             }}
           >
             close
@@ -151,14 +159,13 @@ const InputModal = ({ message, setMessage, handlers, modalStates }) => {
 
 const ListCertBody = ({ data, index, handlers, queryKey }) => {
   const queryClient = useQueryClient();
-
   const { approve, reject } = handlers;
   const [message, setMessage] = useState("");
   const [modalStates, setModalStates] = useState({ open: false, purpose: "" });
 
   const { mutate: approveReq } = useMutation({
     mutationKey: ["approveCertReq", data.id],
-    mutationFn: approve({ message, id: data.memberId }),
+    mutationFn: approve({ message, id: data.id }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [queryKey] });
     },
@@ -166,6 +173,9 @@ const ListCertBody = ({ data, index, handlers, queryKey }) => {
   const { mutate: rejectReq } = useMutation({
     mutationKey: ["rejectCertReq", data.id],
     mutationFn: reject({ data: message, id: data.id }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey] });
+    },
   });
 
   const modalHandlers = {
@@ -193,6 +203,7 @@ const ListCertBody = ({ data, index, handlers, queryKey }) => {
       <div className="button_container">
         <button
           onClick={() => {
+            document.querySelector("body").classList.add("modal_open");
             setModalStates({ open: true, purpose: "approve" });
           }}
         >

--- a/client/src/Components/Admin/List.jsx
+++ b/client/src/Components/Admin/List.jsx
@@ -1,0 +1,306 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { dtFontSize } from "../../styles/mixins";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  /* position: relative; */
+  align-items: center;
+
+  ::after {
+    content: "";
+    width: 95%;
+    margin-top: 10px;
+    border-bottom: 1px solid black;
+  }
+
+  .request_container {
+    /* position: relative; */
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 20px;
+    margin-top: 30px;
+  }
+
+  .info_container {
+    width: 80%;
+    display: flex;
+
+    .info {
+      display: flex;
+      flex-direction: column;
+
+      .written_by {
+        color: #aeaeae;
+        font-size: ${dtFontSize.small};
+      }
+    }
+
+    p {
+      margin-right: 5px;
+    }
+  }
+
+  .button_container {
+    width: 20%;
+    display: flex;
+    justify-content: space-evenly;
+    height: max-content;
+
+    button {
+      padding: 5px;
+
+      :hover {
+        cursor: pointer;
+      }
+    }
+  }
+`;
+
+const Modal = styled.div`
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  top: 0;
+  left: 0;
+  background-color: #00000057;
+  backdrop-filter: blur(20px);
+  z-index: 1;
+
+  form {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 300px;
+    height: 300px;
+
+    .button_container {
+      margin-top: 10px;
+      display: flex;
+    }
+
+    textarea {
+      margin-top: 20px;
+    }
+
+    button {
+      margin-right: 10px;
+      padding: 5px 10px;
+      :hover {
+        cursor: pointer;
+      }
+    }
+  }
+`;
+
+const InputModal = ({ message, setMessage, handlers, modalStates }) => {
+  const { setModalStates, approveReq, rejectReq } = handlers;
+  const { purpose } = modalStates;
+  const sendReqHandler = (purpose) => {
+    return () => {
+      if (purpose === "approve") {
+        approveReq();
+      } else {
+        rejectReq();
+      }
+      setMessage("");
+      setModalStates({ open: false });
+    };
+  };
+
+  return (
+    <Modal>
+      <form>
+        <label htmlFor="message">
+          {purpose === "approve" ? "승인" : "거절"} 이유를 입력하십시오.
+        </label>
+        <textarea
+          rows="5"
+          cols="30"
+          onChange={(e) => {
+            setMessage(e.target.value);
+          }}
+          value={message}
+          id="message"
+        />
+        <div className="button_container">
+          <button onClick={sendReqHandler(purpose)}>send</button>
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              setModalStates({ open: false, purpose: "" });
+              setMessage("");
+            }}
+          >
+            close
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+const ListCertBody = ({ data, index, handlers, queryKey }) => {
+  const queryClient = useQueryClient();
+
+  const { approve, reject } = handlers;
+  const [message, setMessage] = useState("");
+  const [modalStates, setModalStates] = useState({ open: false, purpose: "" });
+
+  const { mutate: approveReq } = useMutation({
+    mutationKey: ["approveCertReq", data.id],
+    mutationFn: approve({ message, id: data.memberId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey] });
+    },
+  });
+  const { mutate: rejectReq } = useMutation({
+    mutationKey: ["rejectCertReq", data.id],
+    mutationFn: reject({ data: message, id: data.id }),
+  });
+
+  const modalHandlers = {
+    setModalStates,
+    approveReq,
+    rejectReq,
+  };
+
+  return (
+    <div className="request_container">
+      {modalStates.open && (
+        <InputModal
+          message={message}
+          setMessage={setMessage}
+          handlers={modalHandlers}
+          modalStates={modalStates}
+        />
+      )}
+      <div className="info_container">
+        <p>{index + 1 + "."}</p>
+        <p data-id={data.memberId} className="username">
+          {data.email}
+        </p>
+      </div>
+      <div className="button_container">
+        <button
+          onClick={() => {
+            setModalStates({ open: true, purpose: "approve" });
+          }}
+        >
+          approve
+        </button>
+        <button
+          onClick={() => {
+            setModalStates({ open: true, purpose: "reject" });
+          }}
+        >
+          reject
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const ListCommentsBody = ({ data, index, handlers, queryKey }) => {
+  const { remove } = handlers;
+  const queryClient = useQueryClient();
+
+  const { mutate: removeComment } = useMutation({
+    mutationKey: ["deleteCommentAdmin", data.id],
+    mutationFn: remove({ id: data.id }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey] });
+    },
+    onError: (err) => {
+      console.log(err);
+    },
+  });
+
+  return (
+    <div className="request_container">
+      <div className="info_container">
+        <p>{index + 1 + "."}</p>
+        <div className="info">
+          <p data-id={data.memberId} className="username">
+            {data.comment}
+          </p>
+          <p className="written_by">{data.nickname}</p>
+        </div>
+      </div>
+      <div className="button_container">
+        <button onClick={removeComment}>remove</button>
+      </div>
+    </div>
+  );
+};
+
+const ListDeletedBody = ({ data, index, handlers, queryKey }) => {
+  const { restore } = handlers;
+  const queryClient = useQueryClient();
+
+  const { mutate: restoreComment } = useMutation({
+    mutationKey: ["restoreCommentAdmin", data.id],
+    mutationFn: restore({ id: data.id }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey] });
+    },
+    onError: (err) => {
+      console.log(err);
+    },
+  });
+
+  return (
+    <div className="request_container">
+      {data ? (
+        <>
+          <div className="info_container">
+            <p>{index + 1 + "."}</p>
+            <div className="info">
+              <p data-id={data.memberId} className="username">
+                {data.comment}
+              </p>
+              <p className="written_by">{data.nickname}</p>
+            </div>
+          </div>
+          <div className="button_container">
+            <button onClick={restoreComment}>restore</button>
+          </div>
+        </>
+      ) : (
+        <p>no data</p>
+      )}
+    </div>
+  );
+};
+
+export default function List(props) {
+  const listBodyReducer = (props) => {
+    const { sort } = props;
+    switch (sort) {
+      case "cert":
+        return ListCertBody(props);
+
+      case "comments":
+        return ListCommentsBody(props);
+
+      case "deleted":
+        return ListDeletedBody(props);
+
+      default:
+        return;
+    }
+  };
+
+  if (props.data) {
+    return <Container>{listBodyReducer(props)}</Container>;
+  }
+}

--- a/client/src/Components/Admin/ListViewer.jsx
+++ b/client/src/Components/Admin/ListViewer.jsx
@@ -13,10 +13,12 @@ const Container = styled.section`
   align-items: center;
   margin-top: 20px;
   width: 70%;
-  height: max-content;
+  max-height: 400px;
   min-height: 100px;
+  overflow-y: scroll;
   border: 1px solid lightgrey;
   padding: 10px 0;
+  margin-top: 40px;
 
   .contents_container {
     display: flex;

--- a/client/src/Components/Admin/ListViewer.jsx
+++ b/client/src/Components/Admin/ListViewer.jsx
@@ -15,8 +15,6 @@ const Container = styled.section`
   width: 70%;
   max-height: 400px;
   min-height: 100px;
-  overflow-y: scroll;
-  border: 1px solid lightgrey;
   padding: 10px 0;
   margin-top: 40px;
 
@@ -26,11 +24,28 @@ const Container = styled.section`
     width: 100%;
     height: max-content;
     padding: 0 30px;
-    /* background-color: blue; */
 
     .contents_title {
       font-size: ${dtFontSize.large};
       font-weight: 600;
+    }
+
+    .list_box {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 300px;
+      border: 1px solid lightgrey;
+      overflow-y: scroll;
+      align-content: center;
+    }
+
+    .null_box {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
   }
 `;
@@ -58,20 +73,24 @@ export default function ListViewer({ listInfo }) {
       <Container>
         <div className="contents_container">
           <p className="contents_title">{title}</p>
-          {listData.length ? (
-            listData.map((data, index) => (
-              <List
-                key={data.id}
-                data={data}
-                index={index}
-                sort={sort}
-                handlers={handlers}
-                queryKey={queryKey}
-              />
-            ))
-          ) : (
-            <p>데이터가 없습니다.</p>
-          )}
+          <div className="list_box">
+            {listData.length ? (
+              listData.map((data, index) => (
+                <List
+                  key={data.id}
+                  data={data}
+                  index={index}
+                  sort={sort}
+                  handlers={handlers}
+                  queryKey={queryKey}
+                />
+              ))
+            ) : (
+              <div className="null_box">
+                <p>데이터가 없습니다.</p>
+              </div>
+            )}
+          </div>
           {!!listPageInfo?.totalPages && (
             <Pagination pageInfo={listPageInfo} setCurPage={setCurPage} />
           )}

--- a/client/src/Components/Admin/ListViewer.jsx
+++ b/client/src/Components/Admin/ListViewer.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import List from "./List";
+import Pagination from "./Pagination";
+import styled from "styled-components";
+import { dtFontSize } from "../../styles/mixins";
+
+import { useQuery } from "@tanstack/react-query";
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+  width: 70%;
+  height: max-content;
+  min-height: 100px;
+  border: 1px solid lightgrey;
+  padding: 10px 0;
+
+  .contents_container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: max-content;
+    padding: 0 30px;
+    /* background-color: blue; */
+
+    .contents_title {
+      font-size: ${dtFontSize.large};
+      font-weight: 600;
+    }
+  }
+`;
+
+export default function ListViewer({ listInfo }) {
+  const [listData, setListData] = useState([]);
+  const [listPageInfo, setlistPageInfo] = useState();
+  const [curPage, setCurPage] = useState(1);
+
+  const { queryKey, queryFn, title, sort, handlers } = listInfo;
+
+  const { isLoading } = useQuery({
+    queryKey: [queryKey, curPage],
+    queryFn: queryFn({ page: 1, size: 12 }),
+    onSuccess: (res) => {
+      const { data, pageInfo } = res.data;
+      setListData(data);
+      setlistPageInfo(pageInfo);
+    },
+    keepPreviousData: true,
+  });
+
+  if (!isLoading) {
+    return (
+      <Container>
+        <div className="contents_container">
+          <p className="contents_title">{title}</p>
+          {listData.length ? (
+            listData.map((data, index) => (
+              <List
+                key={data.id}
+                data={data}
+                index={index}
+                sort={sort}
+                handlers={handlers}
+                queryKey={queryKey}
+              />
+            ))
+          ) : (
+            <p>데이터가 없습니다.</p>
+          )}
+          {!!listPageInfo?.totalPages && (
+            <Pagination pageInfo={listPageInfo} setCurPage={setCurPage} />
+          )}
+        </div>
+      </Container>
+    );
+  }
+}

--- a/client/src/Components/Admin/Pagination.jsx
+++ b/client/src/Components/Admin/Pagination.jsx
@@ -1,0 +1,101 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import React from "react";
+import styled from "styled-components";
+
+const Container = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  margin-top: 20px;
+
+  .button_container {
+    display: flex;
+    align-items: center;
+    width: 20%;
+  }
+
+  .page {
+    :hover {
+      cursor: pointer;
+    }
+  }
+
+  .page.selected {
+    color: blue;
+  }
+`;
+
+export default function Pagination({ pageInfo, setCurPage }) {
+  const pageButtonHandler = (e) => {
+    setCurPage(e.target.value);
+  };
+
+  const generateButtons = (pageInfo, buttonHandler) => {
+    const { totalPages, page: curPage } = pageInfo;
+    const pageStart = 5 * Math.floor(curPage / 6);
+    const lastPageStart = 5 * Math.floor(totalPages / 6);
+
+    const pageGenerate = () => {
+      let result = [];
+      if (totalPages < 5) {
+        result = new Array(totalPages).fill(0);
+        result.reduce((acc) => {
+          result[acc] = acc += 1;
+          return acc;
+        }, 0);
+      } else {
+        if (curPage <= lastPageStart) {
+          result = new Array(5).fill(0);
+        } else {
+          result = new Array(totalPages - lastPageStart).fill(0);
+        }
+        result.reduce((acc) => {
+          result[acc] = pageStart + (acc += 1);
+          return acc;
+        }, 0);
+      }
+
+      return result;
+    };
+
+    return pageGenerate().map((page, i) => {
+      if (page === curPage) {
+        return (
+          <p onClick={buttonHandler} className="page selected" key={"page" + i}>
+            {page}
+          </p>
+        );
+      }
+      return (
+        <p onClick={buttonHandler} className="page" key={"page" + i}>
+          {page}
+        </p>
+      );
+    });
+  };
+
+  if (pageInfo) {
+    return (
+      <Container>
+        <div className="button_container">
+          <button
+            onClick={() => {
+              setCurPage(pageInfo.page--);
+            }}
+          >
+            prev
+          </button>
+          {generateButtons(pageInfo, pageButtonHandler)}
+          <button
+            onClick={() => {
+              setCurPage(pageInfo.page++);
+            }}
+          >
+            next
+          </button>
+        </div>
+      </Container>
+    );
+  }
+}

--- a/client/src/Components/Admin/Pagination.jsx
+++ b/client/src/Components/Admin/Pagination.jsx
@@ -12,10 +12,19 @@ const Container = styled.div`
   .button_container {
     display: flex;
     align-items: center;
+    justify-content: center;
     width: 20%;
+
+    button {
+      :hover {
+        cursor: pointer;
+        background-color: gray;
+      }
+    }
   }
 
   .page {
+    margin: 0 5px;
     :hover {
       cursor: pointer;
     }

--- a/client/src/Components/Admin/adminData.js
+++ b/client/src/Components/Admin/adminData.js
@@ -39,7 +39,7 @@ const PerformerRequest = new AdminData({
 
 const AllCommentsRequest = new AdminData({
   title: "모든 댓글 보기",
-  queryKey: "FetchAllComments",
+  queryKey: ["FetchComments", "ALL"],
   sort: "comments",
   queryFn: (args) => {
     const params = args;
@@ -51,7 +51,7 @@ const AllCommentsRequest = new AdminData({
     remove: (args) => {
       const { id } = args;
       return () => {
-        return instance.delete(`admins/deletedComments/${id}`);
+        return instance.delete(`admins/comments/${id}`);
       };
     },
   },
@@ -59,7 +59,7 @@ const AllCommentsRequest = new AdminData({
 
 const RemovedCommentsRequest = new AdminData({
   title: "삭제된 댓글 보기",
-  queryKey: "FetchRemovedComments",
+  queryKey: ["FetchComments", "DELETED"],
   sort: "deleted",
   queryFn: (args) => {
     const params = args;
@@ -68,7 +68,7 @@ const RemovedCommentsRequest = new AdminData({
     };
   },
   handlers: {
-    resotre: (args) => {
+    restore: (args) => {
       const { id } = args;
       return () => {
         return instance.post(`admins/comments/${id}`);

--- a/client/src/Components/Admin/adminData.js
+++ b/client/src/Components/Admin/adminData.js
@@ -1,0 +1,84 @@
+import instance from "../../api/core/default";
+
+class AdminData {
+  constructor(config) {
+    this.title = config.title;
+    this.queryKey = config.queryKey;
+    this.queryFn = config.queryFn;
+    this.sort = config.sort;
+    this.handlers = config.handlers;
+  }
+}
+
+const PerformerRequest = new AdminData({
+  title: "퍼포머 인증 신청",
+  queryKey: "FetchPerformerCertReq",
+  sort: "cert",
+  queryFn: (args) => {
+    const params = args;
+    return () => {
+      return instance.get("/certifications", { params });
+    };
+  },
+  handlers: {
+    approve: (args) => {
+      const { message, id } = args;
+      return () => {
+        return instance.post(`admins/certifications/${id}`, { message });
+      };
+    },
+
+    reject: (args) => {
+      const { data, id } = args;
+      return () => {
+        return instance.delete(`admins/certifications/${id}`, { data });
+      };
+    },
+  },
+});
+
+const AllCommentsRequest = new AdminData({
+  title: "모든 댓글 보기",
+  queryKey: "FetchAllComments",
+  sort: "comments",
+  queryFn: (args) => {
+    const params = args;
+    return () => {
+      return instance.get("admins/comments", { params });
+    };
+  },
+  handlers: {
+    remove: (args) => {
+      const { id } = args;
+      return () => {
+        return instance.delete(`admins/deletedComments/${id}`);
+      };
+    },
+  },
+});
+
+const RemovedCommentsRequest = new AdminData({
+  title: "삭제된 댓글 보기",
+  queryKey: "FetchRemovedComments",
+  sort: "deleted",
+  queryFn: (args) => {
+    const params = args;
+    return () => {
+      return instance.get("admins/deletedComments", { params });
+    };
+  },
+  handlers: {
+    resotre: (args) => {
+      const { id } = args;
+      return () => {
+        return instance.post(`admins/comments/${id}`);
+      };
+    },
+  },
+});
+
+export const AdminFeatures = [
+  PerformerRequest,
+  AllCommentsRequest,
+  RemovedCommentsRequest,
+];

--- a/client/src/Components/Admin/adminData.js
+++ b/client/src/Components/Admin/adminData.js
@@ -12,7 +12,7 @@ class AdminData {
 
 const PerformerRequest = new AdminData({
   title: "퍼포머 인증 신청",
-  queryKey: "FetchPerformerCertReq",
+  queryKey: "FetchCertReqAdmin",
   sort: "cert",
   queryFn: (args) => {
     const params = args;

--- a/client/src/Components/Header.jsx
+++ b/client/src/Components/Header.jsx
@@ -378,7 +378,7 @@ export default function Header() {
       .finally((response) => {
         localStorage.clear();
         window.alert("로그아웃 되었습니다!");
-        window.location.reload();
+        window.location.replace("/");
       });
   };
 
@@ -448,15 +448,19 @@ export default function Header() {
             마이페이지
           </Link>
         )}
-        {isLogin && userInfo?.role === "PERFORMER" && (
-          <Link
-            className={
-              location.pathname.includes("tickets/create") ? "current" : ""
-            }
-            to={"/tickets/create"}
-          >
-            공연작성하기
-          </Link>
+        {(isLogin && userInfo?.role === "PERFORMER") ||
+          (userInfo?.role === "ADMIN" && (
+            <Link
+              className={
+                location.pathname.includes("tickets/create") ? "current" : ""
+              }
+              to={"/tickets/create"}
+            >
+              공연작성하기
+            </Link>
+          ))}
+        {isLogin && userInfo?.role === "ADMIN" && (
+          <Link to={"/admin/main"}>ADMIN</Link>
         )}
       </HeaderLinkContainer>
       {isLogin ? (
@@ -571,6 +575,22 @@ export default function Header() {
                 >
                   마이페이지
                 </Link>
+              )}
+              {(isLogin && userInfo?.role === "PERFORMER") ||
+                (userInfo?.role === "ADMIN" && (
+                  <Link
+                    className={
+                      location.pathname.includes("tickets/create")
+                        ? "current"
+                        : ""
+                    }
+                    to={"/tickets/create"}
+                  >
+                    공연작성하기
+                  </Link>
+                ))}
+              {isLogin && userInfo?.role === "ADMIN" && (
+                <Link to={"/admin/main"}>ADMIN</Link>
               )}
             </NavbarLinkerContainer>
           </NavbarContainer>

--- a/client/src/Components/Header.jsx
+++ b/client/src/Components/Header.jsx
@@ -441,7 +441,9 @@ export default function Header() {
         {isLogin && (
           <Link
             className={location.pathname.includes("user") ? "current" : ""}
-            to={`/mypage/${userInfo?.role.toLowerCase()}/${userInfo?.id}`}
+            to={`/mypage/${
+              userInfo?.role.toLowerCase() !== "user" ? "performer" : "user"
+            }/${userInfo?.id}`}
           >
             마이페이지
           </Link>
@@ -459,7 +461,11 @@ export default function Header() {
       </HeaderLinkContainer>
       {isLogin ? (
         <UserStatus>
-          <Link to={`/mypage/${userInfo?.role.toLowerCase()}/${userInfo?.id}`}>
+          <Link
+            to={`/mypage/${
+              userInfo?.role.toLowerCase() !== "user" ? "performer" : "user"
+            }/${userInfo?.id}`}
+          >
             <div className="userInfo">
               <p className="welcome">환영합니다!</p>
               <p className="username">
@@ -506,9 +512,11 @@ export default function Header() {
               <NavbarProfileBox>
                 <div className="userInfo">
                   <Link
-                    to={`/mypage/${userInfo?.role.toLowerCase()}/${
-                      userInfo.id
-                    }`}
+                    to={`/mypage/${
+                      userInfo?.role.toLowerCase() !== "user"
+                        ? "performer"
+                        : "user"
+                    }/${userInfo.id}`}
                   >
                     <h2>
                       {`${userInfo?.profile[0].nickname} 님,`}
@@ -555,7 +563,11 @@ export default function Header() {
                   className={
                     location.pathname.includes("user") ? "current" : ""
                   }
-                  to={`/mypage/${userInfo?.role.toLowerCase()}/${userInfo?.id}`}
+                  to={`/mypage/${
+                    userInfo?.role.toLowerCase() !== "user"
+                      ? "performer"
+                      : "user"
+                  }/${userInfo?.id}`}
                 >
                   마이페이지
                 </Link>

--- a/client/src/Components/Profile/_CertLists.jsx
+++ b/client/src/Components/Profile/_CertLists.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { sub, secondary, dtFontSize } from "../../styles/mixins";
+import breakpoint from "../../styles/breakpoint";
+import instance from "../../api/core/default";
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: max-content;
+  padding: 0 5%;
+  margin-bottom: 100px;
+
+  @media screen and (max-width: ${breakpoint.mobile}) {
+    flex-direction: column;
+    align-items: center;
+    padding: 20px 5.13%;
+  }
+
+  .title {
+    align-items: center;
+    display: flex;
+    color: ${secondary.secondary600};
+    display: flex;
+    font-size: ${dtFontSize.xlarge};
+    font-weight: 600;
+    height: 24px;
+    width: 80%;
+    margin: 10px 0 20px 0;
+
+    @media screen and (max-width: ${breakpoint.mobile}) {
+      width: 100%;
+    }
+  }
+
+  .list_container {
+    align-items: center;
+    display: flex;
+    height: max-content;
+    min-height: 250px;
+    width: 80%;
+    background-color: white;
+    border: 1px solid ${sub.sub300};
+    border-radius: 10px;
+    justify-content: space-between;
+    flex-direction: column;
+    padding: 4%;
+
+    @media screen and (max-width: ${breakpoint.mobile}) {
+      width: 100%;
+    }
+  }
+`;
+
+export default function CertLists() {
+  const [data, setData] = useState([]);
+  const { id: memberId } = useParams();
+
+  const fetchCertReq = () => {
+    return instance.get(`/certifications/${memberId}`);
+  };
+
+  const { isLoading } = useQuery({
+    queryKey: ["fetchCertReq"],
+    queryFn: fetchCertReq,
+    onSuccess: (res) => {
+      const { data } = res.data;
+    },
+    onError: (err) => {
+      if (err.status === "404") {
+        console.log("no  data for certreq");
+      }
+    },
+  });
+
+  return (
+    <Container>
+      <div className="title">나의 인증 신청 목록</div>
+      <div className="list_container"></div>
+    </Container>
+  );
+}

--- a/client/src/Pages/Admin/AdminEntry.jsx
+++ b/client/src/Pages/Admin/AdminEntry.jsx
@@ -3,6 +3,8 @@ import styled from "styled-components";
 
 import { useNavigate } from "react-router-dom";
 
+import { ProtectRouter } from "./ProtectRouter";
+
 const Container = styled.div`
   width: 100vw;
   height: 100vh;
@@ -40,15 +42,17 @@ export const AdminEntry = () => {
   };
 
   return (
-    <Container>
-      <div className="button_container">
-        <button data-to="/" onClick={buttonClickHandler}>
-          인디고 페이지 사용하기
-        </button>
-        <button data-to="/admin/main" onClick={buttonClickHandler}>
-          어드민 페이지 사용하기
-        </button>
-      </div>
-    </Container>
+    <ProtectRouter>
+      <Container>
+        <div className="button_container">
+          <button data-to="/" onClick={buttonClickHandler}>
+            인디고 페이지 사용하기
+          </button>
+          <button data-to="/admin/main" onClick={buttonClickHandler}>
+            어드민 페이지 사용하기
+          </button>
+        </div>
+      </Container>
+    </ProtectRouter>
   );
 };

--- a/client/src/Pages/Admin/AdminEntry.jsx
+++ b/client/src/Pages/Admin/AdminEntry.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import styled from "styled-components";
+
+import { useNavigate } from "react-router-dom";
+
+const Container = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .button_container {
+    display: flex;
+    width: 80%;
+    height: max-content;
+    justify-content: space-evenly;
+    align-items: center;
+  }
+
+  button {
+    width: 120px;
+    height: 100px;
+    padding: 0 20px;
+    background-color: azure;
+
+    :hover {
+      cursor: pointer;
+      background-color: gray;
+    }
+  }
+`;
+
+export const AdminEntry = () => {
+  const navigate = useNavigate();
+
+  const buttonClickHandler = (e) => {
+    const { to: pathname } = e.target.dataset;
+    navigate(pathname);
+  };
+
+  return (
+    <Container>
+      <div className="button_container">
+        <button data-to="/" onClick={buttonClickHandler}>
+          인디고 페이지 사용하기
+        </button>
+        <button data-to="/admin/main" onClick={buttonClickHandler}>
+          어드민 페이지 사용하기
+        </button>
+      </div>
+    </Container>
+  );
+};

--- a/client/src/Pages/Admin/AdminMain.jsx
+++ b/client/src/Pages/Admin/AdminMain.jsx
@@ -15,6 +15,7 @@ const Container = styled.div`
   align-items: center;
   background-color: gray;
   color: white;
+  padding-bottom: 50px;
 
   header {
     font-size: ${dtFontSize.xlarge};

--- a/client/src/Pages/Admin/AdminMain.jsx
+++ b/client/src/Pages/Admin/AdminMain.jsx
@@ -1,0 +1,188 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { dtFontSize } from "../../styles/mixins";
+
+const Container = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: gray;
+  color: white;
+
+  header {
+    font-size: ${dtFontSize.xlarge};
+    margin-top: 20px;
+    font-weight: 600;
+  }
+
+  main {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 80%;
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-top: 20px;
+    width: 70%;
+    height: max-content;
+    min-height: 100px;
+    border: 1px solid lightgrey;
+    padding: 10px 0;
+
+    .contents_container {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: max-content;
+      padding: 0 30px;
+      /* background-color: blue; */
+
+      .contents_title {
+        font-size: ${dtFontSize.large};
+        font-weight: 600;
+      }
+    }
+
+    .pagination {
+      display: flex;
+      width: 100%;
+      justify-content: center;
+      margin-top: 20px;
+      /* background-color: purple; */
+
+      .button_container {
+        display: flex;
+        align-items: center;
+        width: 20%;
+      }
+    }
+
+    .request_box {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      position: relative;
+      align-items: center;
+
+      ::after {
+        content: "";
+        width: 95%;
+        margin-top: 10px;
+        border-bottom: 1px solid black;
+      }
+    }
+
+    .request_container {
+      position: relative;
+      display: flex;
+      width: 100%;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0 20px;
+      margin-top: 30px;
+      /* background-color: red; */
+    }
+
+    .info_container {
+      width: 80%;
+      display: flex;
+
+      p {
+        margin-right: 5px;
+      }
+    }
+
+    .button_container {
+      width: 20%;
+      display: flex;
+      justify-content: space-evenly;
+      height: max-content;
+      /* background-color: green; */
+
+      button {
+        padding: 5px;
+
+        :hover {
+          cursor: pointer;
+        }
+      }
+    }
+  }
+`;
+
+export const AdminMain = () => {
+  const [performerData, setPerformerData] = useState([]);
+  const [commentsData, setCommentsData] = useState([]);
+
+  return (
+    <Container>
+      <header>Indiego Admin</header>
+      <main>
+        <section>
+          <div className="contents_container">
+            <p className="contents_title">퍼포머 인증 신청 </p>
+            <div className="request_box">
+              <div className="request_container">
+                <div className="info_container">
+                  <p>1.</p>
+                  <p className="username">username</p>
+                </div>
+                <div className="button_container">
+                  <button>approve</button>
+                  <button>reject</button>
+                </div>
+              </div>
+            </div>
+            <div className="pagination">
+              <div className="button_container">
+                <button>prev</button>
+                <p>1</p>
+                <p>2</p>
+                <p>3</p>
+                <p>4</p>
+                <p>5</p>
+                <button>next</button>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section>
+          <div className="contents_container">
+            <p className="contents_title">모든 댓글</p>
+            <div className="request_box">
+              <div className="request_container">
+                <div className="info_container">
+                  <p>1.</p>
+                  <p className="username">username</p>
+                </div>
+                <div className="button_container">
+                  <button>restore</button>
+                  <button>delete</button>
+                </div>
+              </div>
+            </div>
+            <div className="pagination">
+              <div className="button_container">
+                <button>prev</button>
+                <p>1</p>
+                <p>2</p>
+                <p>3</p>
+                <p>4</p>
+                <p>5</p>
+                <button>next</button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </Container>
+  );
+};

--- a/client/src/Pages/Admin/AdminMain.jsx
+++ b/client/src/Pages/Admin/AdminMain.jsx
@@ -8,7 +8,8 @@ import { AdminFeatures } from "../../Components/Admin/adminData";
 
 const Container = styled.div`
   width: 100vw;
-  height: 100vh;
+  min-height: 100vh;
+  height: max-content;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/client/src/Pages/Admin/AdminMain.jsx
+++ b/client/src/Pages/Admin/AdminMain.jsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { dtFontSize } from "../../styles/mixins";
+import { ProtectRouter } from "./ProtectRouter";
+
+import ListViewer from "../../Components/Admin/ListViewer";
+import { AdminFeatures } from "../../Components/Admin/adminData";
 
 const Container = styled.div`
   width: 100vw;
@@ -24,165 +28,20 @@ const Container = styled.div`
     align-items: center;
     width: 80%;
   }
-
-  section {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    margin-top: 20px;
-    width: 70%;
-    height: max-content;
-    min-height: 100px;
-    border: 1px solid lightgrey;
-    padding: 10px 0;
-
-    .contents_container {
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-      height: max-content;
-      padding: 0 30px;
-      /* background-color: blue; */
-
-      .contents_title {
-        font-size: ${dtFontSize.large};
-        font-weight: 600;
-      }
-    }
-
-    .pagination {
-      display: flex;
-      width: 100%;
-      justify-content: center;
-      margin-top: 20px;
-      /* background-color: purple; */
-
-      .button_container {
-        display: flex;
-        align-items: center;
-        width: 20%;
-      }
-    }
-
-    .request_box {
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-      position: relative;
-      align-items: center;
-
-      ::after {
-        content: "";
-        width: 95%;
-        margin-top: 10px;
-        border-bottom: 1px solid black;
-      }
-    }
-
-    .request_container {
-      position: relative;
-      display: flex;
-      width: 100%;
-      justify-content: space-between;
-      align-items: center;
-      padding: 0 20px;
-      margin-top: 30px;
-      /* background-color: red; */
-    }
-
-    .info_container {
-      width: 80%;
-      display: flex;
-
-      p {
-        margin-right: 5px;
-      }
-    }
-
-    .button_container {
-      width: 20%;
-      display: flex;
-      justify-content: space-evenly;
-      height: max-content;
-      /* background-color: green; */
-
-      button {
-        padding: 5px;
-
-        :hover {
-          cursor: pointer;
-        }
-      }
-    }
-  }
 `;
 
 export const AdminMain = () => {
-  const [performerData, setPerformerData] = useState([]);
-  const [commentsData, setCommentsData] = useState([]);
-
   return (
-    <Container>
-      <header>Indiego Admin</header>
-      <main>
-        <section>
-          <div className="contents_container">
-            <p className="contents_title">퍼포머 인증 신청 </p>
-            <div className="request_box">
-              <div className="request_container">
-                <div className="info_container">
-                  <p>1.</p>
-                  <p className="username">username</p>
-                </div>
-                <div className="button_container">
-                  <button>approve</button>
-                  <button>reject</button>
-                </div>
-              </div>
-            </div>
-            <div className="pagination">
-              <div className="button_container">
-                <button>prev</button>
-                <p>1</p>
-                <p>2</p>
-                <p>3</p>
-                <p>4</p>
-                <p>5</p>
-                <button>next</button>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section>
-          <div className="contents_container">
-            <p className="contents_title">모든 댓글</p>
-            <div className="request_box">
-              <div className="request_container">
-                <div className="info_container">
-                  <p>1.</p>
-                  <p className="username">username</p>
-                </div>
-                <div className="button_container">
-                  <button>restore</button>
-                  <button>delete</button>
-                </div>
-              </div>
-            </div>
-            <div className="pagination">
-              <div className="button_container">
-                <button>prev</button>
-                <p>1</p>
-                <p>2</p>
-                <p>3</p>
-                <p>4</p>
-                <p>5</p>
-                <button>next</button>
-              </div>
-            </div>
-          </div>
-        </section>
-      </main>
-    </Container>
+    <ProtectRouter>
+      <Container>
+        {/* <InputModal message={message} setMessage={setMessage} /> */}
+        <header>Indiego Admin</header>
+        <main>
+          {AdminFeatures.map((listInfo, index) => {
+            return <ListViewer key={index} listInfo={listInfo} />;
+          })}
+        </main>
+      </Container>
+    </ProtectRouter>
   );
 };

--- a/client/src/Pages/Admin/ProtectRouter.jsx
+++ b/client/src/Pages/Admin/ProtectRouter.jsx
@@ -1,0 +1,19 @@
+import React, { useLayoutEffect, useState } from "react";
+
+export const ProtectRouter = ({ children }) => {
+  const [authorized, setAuthorized] = useState(false);
+
+  useLayoutEffect(() => {
+    const userInfoStorage = JSON.parse(localStorage.getItem("userInfoStorage"));
+    if (userInfoStorage && userInfoStorage.role === "ADMIN") {
+      setAuthorized(true);
+    } else {
+      window.alert("NOT AUTHORIZED USER");
+      window.location.replace("/");
+    }
+  });
+
+  if (authorized) {
+    return children;
+  }
+};

--- a/client/src/Pages/AdminLogin.jsx
+++ b/client/src/Pages/AdminLogin.jsx
@@ -1,0 +1,133 @@
+import React, { useState } from "react";
+
+import styled from "styled-components";
+
+import axios, { AxiosError } from "axios";
+import { useMutation } from "@tanstack/react-query";
+import useIsLoginStore from "../store/useIsLoginStore";
+
+const Container = styled.div`
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: #323232;
+  color: white;
+
+  form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    label {
+      margin-top: 10px;
+    }
+
+    input {
+      margin-top: 10px;
+    }
+
+    button {
+      padding: 5px 10px;
+      margin-top: 30px;
+
+      :hover {
+        cursor: pointer;
+        background-color: blue;
+        color: white;
+      }
+    }
+
+    input#keep_login {
+      margin-left: 10px;
+    }
+  }
+`;
+
+export const AdminLogin = () => {
+  const [emailInput, setEmailInput] = useState("");
+  const [passwordInput, setPasswordInput] = useState("");
+  const [keepLogin, setKeepLogin] = useState(false);
+  const { setIsLogin } = useIsLoginStore((state) => state);
+
+  const requestAdminLogin = () => {
+    const data = { email: emailInput, password: passwordInput, role: "ADMIN" };
+    return axios.post(
+      process.env.REACT_APP_SERVER_URI + "/members/login",
+      data
+    );
+  };
+
+  const { mutate: submitLoginForm } = useMutation({
+    mutationFn: requestAdminLogin,
+    mutationKey: "requestAdminLogin",
+    onSuccess: (response) => {
+      if (keepLogin) {
+        localStorage.setItem("refreshToken", response.headers.get("Refresh"));
+      }
+      localStorage.setItem(
+        "accessToken",
+        response.headers.get("Authorization").split(" ")[1]
+      );
+      localStorage.setItem(
+        "userInfoStorage",
+        JSON.stringify(response.data.data)
+      );
+      setIsLogin("hi!");
+      window.location.replace("/admin");
+    },
+    onError: (err) => {
+      throw new AxiosError(err);
+    },
+  });
+
+  const handleChange = (e) => {
+    if (e.target.id === "password") {
+      setPasswordInput(e.target.value);
+    } else {
+      setEmailInput(e.target.value);
+    }
+  };
+
+  const formSubmitHandler = (e) => {
+    e.preventDefault();
+    submitLoginForm();
+  };
+
+  return (
+    <Container>
+      <h1>Indiego Admin Login</h1>
+      <form>
+        <label htmlFor="email">Admin Email</label>
+        <input
+          onChange={handleChange}
+          value={emailInput}
+          placeholder="admin email"
+          id="email"
+        />
+        <label htmlFor="password">Admin Password</label>
+        <input
+          value={passwordInput}
+          placeholder="admin password"
+          type="password"
+          id="password"
+          onChange={handleChange}
+        />
+        <div className="checkbox_container">
+          <label htmlFor="keep_login">keep login</label>
+          <input
+            onChange={(e) => {
+              setKeepLogin(!e.target.value);
+            }}
+            value={keepLogin}
+            id="keep_login"
+            type="checkbox"
+          ></input>
+        </div>
+        <button onClick={formSubmitHandler}>submit</button>
+      </form>
+    </Container>
+  );
+};

--- a/client/src/Pages/Profile/ProfilePerformer.jsx
+++ b/client/src/Pages/Profile/ProfilePerformer.jsx
@@ -23,7 +23,7 @@ import { React, useState, useEffect, useLayoutEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components/macro";
 import AllShowListPerformer from "../../Components/Profile/AllShowListPerformer.jsx";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
 
 const Container = styled.div`
   align-items: center;
@@ -98,26 +98,41 @@ const ContentInnerContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: max-content;
-  padding: 5%;
+  height: 500px;
+  padding: 0 5%;
 
   @media screen and (max-width: ${breakpoint.mobile}) {
     flex-direction: column;
     align-items: center;
     padding: 20px 5%;
+    height: max-content;
   }
 `;
 
 const ProfileInfoContainer = styled.div`
-  align-items: flex-start;
+  align-items: center;
   border-bottom: 1px solid ${sub.sub100};
   display: flex;
   justify-content: space-between;
   width: 100%;
-  padding-bottom: 20px;
+  height: 40%;
+  min-height: 150px;
 
   @media screen and (max-width: ${breakpoint.mobile}) {
     flex-direction: column;
+    padding-bottom: 10px;
+  }
+
+  .performer-profile-container {
+    display: flex;
+    height: 100%;
+    align-items: center;
+  }
+
+  .performer-info-container {
+    display: flex;
+    flex-direction: column;
+    padding: 25px 20px;
   }
 
   > div {
@@ -127,8 +142,8 @@ const ProfileInfoContainer = styled.div`
     > img {
       border: 2px solid ${sub.sub200};
       border-radius: 100%;
-      height: 140px;
-      width: 140px;
+      height: 120px;
+      width: 120px;
 
       @media screen and (max-width: ${breakpoint.mobile}) {
         height: 80px;
@@ -139,7 +154,6 @@ const ProfileInfoContainer = styled.div`
     > div {
       display: flex;
       flex-direction: column;
-      margin: 0 0 4% 7%;
 
       @media screen and (max-width: ${breakpoint.mobile}) {
         margin-left: 4%;
@@ -199,7 +213,10 @@ const ProfileInfoContainer = styled.div`
 
   > .button-container {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-evenly;
+    height: 70%;
 
     @media screen and (max-width: ${breakpoint.mobile}) {
       margin-top: 15px;
@@ -218,6 +235,7 @@ const ProfileInfoContainer = styled.div`
       padding: 5px 20px;
       width: max-content;
       text-align: center;
+      margin-top: 10px;
 
       &:hover {
         background-color: ${primary.primary200};
@@ -333,6 +351,29 @@ export default function Profile() {
     navigate(`/mypage/${params.id}/edit`);
   };
 
+  /** 퍼포머 인증신청 관련 */
+
+  const approveRequest = () => {
+    const { id: memberId } = profileData;
+    const data = { memberId };
+    return instance({
+      method: "post",
+      data: data,
+      url: "/certifications",
+    });
+  };
+
+  const { mutate: approveRequestButtonHandler } = useMutation({
+    mutationFn: approveRequest,
+    mutationKey: "performerRequest",
+    onSuccess: (res) => {
+      console.log(res);
+    },
+    onError: (err) => {
+      console.log(err);
+    },
+  });
+
   return (
     <Container>
       <WithdrawModal />
@@ -344,12 +385,12 @@ export default function Profile() {
       <ContentContainer>
         <ContentInnerContainer>
           <ProfileInfoContainer>
-            <div>
+            <div className="performer-profile-container">
               <img
                 alt="dummy profile"
                 src={profileData && profileData.profile[0].image}
               />
-              <div>
+              <div className="performer-info-container">
                 <span className="performer-nickname">
                   {profileData && profileData.profile[0].nickname}
                 </span>
@@ -368,6 +409,12 @@ export default function Profile() {
                 onClick={handleMoveToEditPage}
               >
                 프로필 수정하기
+              </button>
+              <button
+                className="profile-edit-button"
+                onClick={approveRequestButtonHandler}
+              >
+                퍼포머 인증 신청하기
               </button>
             </div>
           </ProfileInfoContainer>

--- a/client/src/Pages/Signup/SignupPerformer.jsx
+++ b/client/src/Pages/Signup/SignupPerformer.jsx
@@ -351,7 +351,7 @@ export default function SignupPerformer() {
     nickname: nickname,
     email: email,
     password: password,
-    role: "PERFORMER",
+    role: "NON_CERTIFIED_PERFORMER",
   };
 
   const postSignupData = () => {


### PR DESCRIPTION
### [도입 배경]
1. 퍼포머 인증신청 관리를 위해 ADMIN 페이지 추가 논의

### [Major Change]
1. /login/admin 경로로 어드민 로그인 페이지로 진입 가능합니다.
2. ADMIN 페이지에서는 퍼포머 인증신청을 메세지와 함께 수락 / 거절 할 수 있습니다.
3. ADMIN 페이지는 모든 댓글을 조회할 수 있고 삭제 / 복구가 가능합니다. 해당 댓글은 완전히 삭제 되지 않으며 해당 게시글에 곧 바로 결과가 적용됩니다.
4. 지정된 사용자가 아니면 ADMIN 페이지에 접근할 수 없습니다. (email : hgd1234@naver.com / pw: ghdrlfehd1234!)
5. 퍼포머는 이제 마이페이지에서 퍼포머 인증 요청을 할 수 있습니다. 인증과 관련한 상태가 마이페이지에 표시됩니다.

### [Read Me]
1. PerformerProfile.jsx 가 인증 요청관련해서 수정된 부분이 있습니다. 기존 코드에 영향을 미치는 부분은 존재하지 않으나, 확인이 필요합니다.
2. Admin 페이지 관련한 코드들이 디렉토리에 추가되었습니다.
3. Header.jsx, APP.jsx  에도 일부 라우팅 및 이동 관련 코드들이 추가되었습니다.
4. _CertList.jsx는 사용자의 인증내역을 보여주기 위한 컴포넌트였으나, 현재 기능이 준비되지 않았기 때문에 사용하지 않습니다.