### PR TITLE
[Feat -> Dev/fe] 프론트 GraphQL 쿼리 적용

### DIFF
--- a/client/src/Components/Main/Carousels/Carousel.jsx
+++ b/client/src/Components/Main/Carousels/Carousel.jsx
@@ -150,7 +150,7 @@ export default function Carousel({ isRankMode, status, address }) {
   };
 
   const { isLoading } = useQuery({
-    queryKey: ["fetchShowData", status, "GQL"],
+    queryKey: ["fetchShowDataGQL", status, address],
     queryFn: gqlFetchShowData,
     onSuccess: fetchShowDataOnSuccess,
   });

--- a/client/src/Components/Main/Carousels/Carousel.jsx
+++ b/client/src/Components/Main/Carousels/Carousel.jsx
@@ -108,12 +108,12 @@ export default function Carousel({ isRankMode, status, address }) {
   const [transition, setTransition] = useState(true);
   const serverURI = process.env.REACT_APP_SERVER_URI;
 
-  console.log(data);
+  // console.log(data);
 
-  const fetchShowData = () => {
-    const params = { status, address };
-    return axios.get(`${serverURI}/shows`, { params });
-  };
+  // const fetchShowData = () => {
+  //   const params = { status, address };
+  //   return axios.get(`${serverURI}/shows`, { params });
+  // };
 
   const fetchShowDataOnSuccess = (response) => {
     const data = response.data.data;
@@ -125,11 +125,34 @@ export default function Carousel({ isRankMode, status, address }) {
     setData(data);
   };
 
+  // const { isLoading } = useQuery({
+  //   queryKey: ["fetchShowData", status],
+  //   queryFn: fetchShowData,
+  //   onSuccess: fetchShowDataOnSuccess,
+  //   retry: false,
+  // });
+
+  // GraphQl
+  const gqlFetchShowData = () => {
+    const query = `
+    query GetSortShows($address: String, $status: String) {
+      getSortShows(address: $address, status: $status) {
+        data {
+          id
+          nickname
+        }
+      }
+    }`;
+    const variables = { address, status };
+    const data = { query, variables };
+
+    return axios.post(`${serverURI}/graphql`, data);
+  };
+
   const { isLoading } = useQuery({
-    queryKey: ["fetchShowData", status],
-    queryFn: fetchShowData,
+    queryKey: ["fetchShowData", status, "GQL"],
+    queryFn: gqlFetchShowData,
     onSuccess: fetchShowDataOnSuccess,
-    retry: false,
   });
 
   useInterval(() => {

--- a/client/src/Components/Profile/AllShowListPerformer.jsx
+++ b/client/src/Components/Profile/AllShowListPerformer.jsx
@@ -88,29 +88,48 @@ export default function AllShowList() {
   const [isExpiredDataExist, setIsExpiredDataExist] = useState(true);
   const [isNotExpiredDataExist, setIsNotExpiredDataExist] = useState(true);
 
-  const fetchData = () => {
-    return instance({
-      method: "get",
-      url: "/shows/seller",
-    });
-  };
-
   const fetchDataOnSuccess = (response) => {
-    setData(response.data.data && response.data.data);
+    const { getShowOfSeller: data } = response.data.data;
+    setData(data);
   };
 
-  const fetchDataOnError = (err) => {
+  const fetchDataOnError = () => {
     window.alert("일시적인 오류입니다. 잠시 후에 다시 시도해주세요.");
+  };
+  // graphQl
+  const gqlFetchData = () => {
+    const query = `
+        query GetShowOfSeller($page: Int, $size: Int) {
+          getShowOfSeller(page: $page, size: $size) {
+              id
+              title
+              nickname
+              showAt
+              expiredAt
+              address
+              detailAddress
+              image
+              emptySeats
+              revenue
+              isExpired
+          }
+        }
+      `;
+
+    const data = { query };
+
+    return instance.post(`${process.env.REACT_APP_SERVER_URI}/graphql`, data);
   };
 
   const { isLoading } = useQuery({
-    queryKey: ["fetchData"],
-    queryFn: fetchData,
+    queryFn: gqlFetchData,
+    queryKey: ["GQLFetchSellShows"],
     keepPreviousData: true,
     onSuccess: fetchDataOnSuccess,
     onError: fetchDataOnError,
     retry: false,
   });
+  // graphQl
 
   const notExpiredData = data && data.filter((data) => data.expired === false);
   const expiredData = data && data.filter((data) => data.expired === true);

--- a/client/src/Components/Profile/AllShowListPerformer.jsx
+++ b/client/src/Components/Profile/AllShowListPerformer.jsx
@@ -123,7 +123,7 @@ export default function AllShowList() {
 
   const { isLoading } = useQuery({
     queryFn: gqlFetchData,
-    queryKey: ["GQLFetchSellShows"],
+    queryKey: ["FetchSellShowsGQL"],
     keepPreviousData: true,
     onSuccess: fetchDataOnSuccess,
     onError: fetchDataOnError,

--- a/client/src/Components/Ticktes/CardItem.jsx
+++ b/client/src/Components/Ticktes/CardItem.jsx
@@ -114,7 +114,7 @@ export default function CardItem({ data }) {
               ? `${data.showAt} - ${data.expiredAt}`
               : ""}
           </h4>
-          <h4>{data.detailAddress}</h4>
+          <h4>{data.address}</h4>
         </DetailContainer>
       </Link>
     </CardItemContainer>

--- a/client/src/Pages/Home.jsx
+++ b/client/src/Pages/Home.jsx
@@ -16,7 +16,9 @@ const DatePopup = React.lazy(() =>
 import { dtFontSize, primary, sub } from "../styles/mixins.js";
 import breakpoint from "../styles/breakpoint.js";
 import instance from "../api/core/default.js";
-
+// test
+import axios from "axios";
+// test
 import styled from "styled-components";
 import { useQuery } from "@tanstack/react-query";
 

--- a/client/src/Pages/Tickets/Tickets.jsx
+++ b/client/src/Pages/Tickets/Tickets.jsx
@@ -228,7 +228,6 @@ export default function Tickets() {
 
   const fetchShowDataOnSuccess = (response) => {
     const { data, pageInfo } = response.data.data.getShow;
-    console.log(data, pageInfo);
     setData(data);
     setPageInfo(pageInfo);
   };
@@ -262,7 +261,7 @@ export default function Tickets() {
         data {
           id
           nickname
-          detailAddress
+          address
           title
           image
           category
@@ -289,7 +288,7 @@ export default function Tickets() {
   };
 
   useQuery({
-    queryKey: ["fetchShowDataGQL"],
+    queryKey: ["fetchShowDataGQL", ...queryParams],
     queryFn: gqlFetchShowData,
     onSuccess: fetchShowDataOnSuccess,
     refetchOnWindowFocus: false,

--- a/client/src/Pages/Tickets/TicketsDetail.jsx
+++ b/client/src/Pages/Tickets/TicketsDetail.jsx
@@ -500,26 +500,68 @@ export default function TicketsDetail() {
     }
   }, [ticketCount]);
 
-  const fetchData = () => {
-    return axios.get(`${process.env.REACT_APP_SERVER_URI}/shows/${params.id}`);
-  };
-
   const fetchDataOnSuccess = (response) => {
-    setTicketData(response.data.data && response.data.data);
+    const { getShowById: data } = response.data.data;
+    console.log(data);
+    setTicketData(data);
   };
 
-  const fetchDataOnError = (error) => {
+  const fetchDataOnError = () => {
     navigate("/notFound");
   };
 
-  const { isLoading } = useQuery({
-    queryKey: ["fetchData"],
-    queryFn: fetchData,
-    keepPreviousData: false,
+  // graphQl
+  const gqlFetchData = () => {
+    const query = `
+      query GetShowById($showId : ID!) {
+        getShowById(showId: $showId) {
+          id
+          sellerId
+          title
+          content
+          image
+          category
+          price
+          address
+          detailAddress
+          expiredAt
+          showAt
+          showTime
+          detailDescription
+          latitude
+          longitude
+          status
+          scoreAverage
+          total
+          emptySeats
+          bookmarked
+          nickname
+          tags {
+            tagId
+            name
+            backgroundColor
+            textColor
+            type
+          }
+        }
+      }
+    `;
+
+    const variables = { showId: params.id };
+    const data = { query, variables };
+
+    return axios.post(`${process.env.REACT_APP_SERVER_URI}/graphql`, data);
+  };
+
+  useQuery({
+    queryFn: gqlFetchData,
+    queryKey: ["GQLFetchShowData"],
     onSuccess: fetchDataOnSuccess,
     onError: fetchDataOnError,
     retry: false,
   });
+
+  // graphQl
 
   const handleMoveToEditPage = () => {
     navigate(`/tickets/${params.id}/edit`);

--- a/client/src/Pages/Tickets/TicketsDetail.jsx
+++ b/client/src/Pages/Tickets/TicketsDetail.jsx
@@ -560,7 +560,6 @@ export default function TicketsDetail() {
     onError: fetchDataOnError,
     retry: false,
   });
-
   // graphQl
 
   const handleMoveToEditPage = () => {


### PR DESCRIPTION
### [도입배경]
백엔드 공연 조회 API 가 GraphQL로 변경됨에 따라 프론트엔드 쿼리에도 GraphQL 적용 필요

### [Major Change]
1. 공연조회 관련 (메인-캐러셀, 티켓검색, 티켓상세, 판매자프로필-판매된공연조회) 쿼리를 모두 GraphQL 쿼리로 변경합니다.
2. 쿼리 이후 로직은 전부 동일합니다.