### PR TITLE
[Feat -> Dev/be] 결제 기능 추가 및 수정

### DIFF
--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/config/PaymentConfig.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/config/PaymentConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class PaymentConfig {
 
-    public static final String URL = "https://api.tosspayments.com/v1/payments/confirm";
+    public static final String URL = "https://api.tosspayments.com/v1/payments/";
 
     @Value("${payments.toss.test_client_key}")
     private String testClientKey;

--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/controller/PaymentController.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/controller/PaymentController.java
@@ -2,22 +2,26 @@ package codestates.frogroup.indiego.domain.payment.controller;
 
 import codestates.frogroup.indiego.domain.payment.dto.PaymentRequestDto;
 import codestates.frogroup.indiego.domain.payment.dto.PaymentResponseDto;
+import codestates.frogroup.indiego.domain.payment.dto.PaymentShowInfo;
+import codestates.frogroup.indiego.domain.payment.mapper.PaymentMapper;
 import codestates.frogroup.indiego.domain.payment.service.PaymentService;
 import codestates.frogroup.indiego.global.dto.SingleResponseDto;
 import codestates.frogroup.indiego.global.security.auth.loginresolver.LoginMemberId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Validated
 @RestController
-@RequestMapping("/payments")
+@RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
 public class PaymentController {
 
     private final PaymentService paymentService;
+    private final PaymentMapper mapper;
 
     @PostMapping
     public ResponseEntity requestPayment(@LoginMemberId Long memberId,
@@ -31,10 +35,11 @@ public class PaymentController {
     @PostMapping("/success")
     public ResponseEntity paymentSuccess(@RequestParam String paymentKey,
                                          @RequestParam String orderId,
-                                         @RequestParam Long amount) {
+                                         @RequestParam Long amount,
+                                         @RequestBody PaymentShowInfo paymentShowInfo,
+                                         @RequestHeader(name = "Authorization") String token) {
 
-        return new ResponseEntity<>(new SingleResponseDto<>(
-                paymentService.paymentSuccess(paymentKey, orderId, amount)), HttpStatus.OK);
+        return new ResponseEntity<>(paymentService.paymentSuccess(paymentKey, orderId, amount, paymentShowInfo, token), HttpStatus.OK);
     }
 
     @PostMapping("/fail")
@@ -44,7 +49,16 @@ public class PaymentController {
 
         paymentService.paymentFail(message, orderId);
 
-        return new ResponseEntity<>(
-                new SingleResponseDto<>(paymentService.createPaymentFailDto(code, message, orderId)), HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResponseDto<>(
+                mapper.createPaymentFailDto(code, message, orderId)), HttpStatus.OK);
+    }
+
+    @PostMapping("/cancel")
+    public ResponseEntity cancelPayment(@LoginMemberId Long memberId,
+                                        @RequestParam String paymentKey,
+                                        @RequestParam String cancelReason) {
+
+        return new ResponseEntity<>(new SingleResponseDto<>(
+                paymentService.cancelPayment(memberId, paymentKey, cancelReason)), HttpStatus.OK);
     }
 }

--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/dto/PaymentRequestDto.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/dto/PaymentRequestDto.java
@@ -1,6 +1,7 @@
 package codestates.frogroup.indiego.domain.payment.dto;
 
 import codestates.frogroup.indiego.domain.payment.entity.Payment;
+import codestates.frogroup.indiego.domain.payment.enums.PaymentStatus;
 import codestates.frogroup.indiego.domain.payment.enums.PaymentType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.UUID;
+
 
 @Data
 @Builder
@@ -27,7 +29,7 @@ public class PaymentRequestDto {
                 .orderId(UUID.randomUUID().toString())
                 .paymentType(paymentType)
                 .orderName(orderName)
-                .paymentApproved(false)
+                .paymentStatus(PaymentStatus.READY)
                 .build();
     }
 }

--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/dto/PaymentResponseDto.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/dto/PaymentResponseDto.java
@@ -12,23 +12,17 @@ import java.time.LocalDateTime;
 public class PaymentResponseDto {
 
     private String paymentType;
-
     private Long amount;
-
     private String orderId;
-
     private String orderName;
 
     private String customerEmail;
-
     private String customerName;
 
     private LocalDateTime createdAt;
-
     private LocalDateTime modifiedAt;
 
-    private String successUrl;
-
-    private String failUrl;
+    private boolean cancel;
+    private String cancelReason;
 
 }

--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/dto/PaymentShowInfo.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/dto/PaymentShowInfo.java
@@ -1,0 +1,23 @@
+package codestates.frogroup.indiego.domain.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentShowInfo {
+
+    @NotNull
+    private Long showId;
+    @NotNull
+    private LocalDate date;
+    @NotNull
+    private Integer ticketCount;
+}

--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/entity/Payment.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/entity/Payment.java
@@ -3,6 +3,7 @@ package codestates.frogroup.indiego.domain.payment.entity;
 import codestates.frogroup.indiego.domain.common.auditing.BaseTime;
 import codestates.frogroup.indiego.domain.member.entity.Member;
 import codestates.frogroup.indiego.domain.payment.dto.PaymentResponseDto;
+import codestates.frogroup.indiego.domain.payment.enums.PaymentStatus;
 import codestates.frogroup.indiego.domain.payment.enums.PaymentType;
 import lombok.*;
 
@@ -35,13 +36,20 @@ public class Payment extends BaseTime {
     private String orderName;
 
     @Column(nullable = false)
-    private boolean paymentApproved;
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus paymentStatus;
 
     @Column
     private String failDescription;
 
     @Column
     private String paymentKey;
+
+    @Column
+    private boolean cancel;
+
+    @Column
+    private String cancelReason;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "customer")

--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/enums/PaymentStatus.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/enums/PaymentStatus.java
@@ -1,0 +1,17 @@
+package codestates.frogroup.indiego.domain.payment.enums;
+
+import lombok.Getter;
+
+public enum PaymentStatus {
+    READY("결제 준비"),
+    PAID("결제 성공"),
+    FAILED("결제 실패"),
+    CANCELLED("결제 취소");
+
+    @Getter
+    private final String status;
+
+    PaymentStatus(String status) {
+        this.status = status;
+    }
+}

--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/enums/PaymentType.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/enums/PaymentType.java
@@ -6,7 +6,7 @@ public enum PaymentType {
     CARD("카드"),
     ACCOUNT_TRANSFER("계좌이체"),
     VIRTUAL_ACCOUNT("가상계좌"),
-    CELL_PHONE("토스페이");
+    TOSS_PAY("토스페이");
 
     @Getter
     private final String type;

--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/mapper/PaymentMapper.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/mapper/PaymentMapper.java
@@ -1,0 +1,16 @@
+package codestates.frogroup.indiego.domain.payment.mapper;
+
+import codestates.frogroup.indiego.domain.payment.dto.PaymentFailDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PaymentMapper {
+
+    default PaymentFailDto createPaymentFailDto(String code, String message, String orderId) {
+        return PaymentFailDto.builder()
+                .errorCode(code)
+                .errorMessage(message)
+                .orderId(orderId)
+                .build();
+    }
+}

--- a/server/src/main/java/codestates/frogroup/indiego/domain/payment/repository/PaymentRepository.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/payment/repository/PaymentRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByOrderId(String orderId);
+    Optional<Payment> findByPaymentKeyAndCustomer_Email(String paymentKey, String email);
 }

--- a/server/src/main/java/codestates/frogroup/indiego/global/dto/PagelessMultiResponseDto.java
+++ b/server/src/main/java/codestates/frogroup/indiego/global/dto/PagelessMultiResponseDto.java
@@ -2,11 +2,13 @@ package codestates.frogroup.indiego.global.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class PagelessMultiResponseDto<T> {
     private List<T> data;
 }

--- a/server/src/main/java/codestates/frogroup/indiego/global/exception/ExceptionCode.java
+++ b/server/src/main/java/codestates/frogroup/indiego/global/exception/ExceptionCode.java
@@ -53,6 +53,8 @@ public enum ExceptionCode {
     PAYMENT_TYPE_NOT_AVAILABLE(400, "사용할 수 없는 결제 수단입니다."),
     AMOUNT_NOT_EQUAL(400, "금액이 일치하지 않습니다."),
     PAYMENT_ALREADY_APPROVED(409, "이미 인증된 결제입니다."),
+    PAYMENT_TYPE_NOT_EQUALS(400, "불가능한 결제 수단입니다."),
+    PAYMENT_AUTHORIZATION_FAILED(406, "결제 승인에 실패하였습니다."),
 
     // File Upload
     UPLOAD_FAILED(404, "File Upload Failed !"),


### PR DESCRIPTION
## 유의해서 봐야할 커밋
- [POST] api/v1/payments/success 서비스 로직
- 결제 수단 추가: 계좌이체, 가상계좌, 토스페이 결제
- 결제 취소 추가
- 결제 승인 시 공연예약 API 호출

## 배경
전반적으로 부족했던 결제 기능을 추가 및 수정하였습니다.
계좌이체, 가상계좌, 토스페이 등의 결제도 진행하기 위해 결제 수단에 따른 결제 요청을 보내도록 하였고,
결제 요청, 승인, 취소, 실패 등에 따라 해당 결제의 상태를 관리할 수 있도록 수정하였습니다.

결제 승인 후 결제 예약 API를 서버에서 내부적으로 호출하여 기존 로직을 재사용하는 방안으로 로직을 작성하였습니다.
- 결제 승인 후 성공하면 결제 예약 API 호출, 해당 공연에 대한 정보가 업데이트 됨,
- 유저, 퍼포머의 마이페이지에서 결제 및 예약 정보를 확인할 수 있을 것으로 예상됨.