### PR TITLE
[feat -> dev] #113 어드민 로직 수정

### DIFF
--- a/server/src/main/java/codestates/frogroup/indiego/domain/admin/CertificationService.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/admin/CertificationService.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 public interface CertificationService {
     CertificationDto.Response createCertication(Certification certification, Long memberId);
     ResponseEntity deleteCertification(Long certificationId, Long memberId);
-    CertificationDto.Response findCertification(Long memberId, Long tokenMemberId);
+    Certification findCertification(Long memberId, Long tokenMemberId);
     public Page<Certification> findAllCertification(int page, int size);
 
     CertificationDto.Response patchCertification(Certification certification, Long certificatedId, Long memberId);

--- a/server/src/main/java/codestates/frogroup/indiego/domain/admin/CertificationServiceImpl.java
+++ b/server/src/main/java/codestates/frogroup/indiego/domain/admin/CertificationServiceImpl.java
@@ -54,20 +54,18 @@ public class CertificationServiceImpl implements CertificationService{
     }
 
     @Override
-    public CertificationDto.Response findCertification(Long certiId, Long tokenMeberId) {
+    public Certification findCertification(Long certiId, Long tokenMeberId) {
 
-        Certification certification = certificationRepository.findById(certiId).orElseThrow(
-                () -> new BusinessLogicException(ExceptionCode.CERTIFICATION_NOT_FOUND)
-        );
+        Certification certification = findVerifiedCertification(certiId);
 
-//        //어드민이 아니고 토큰 멤버 아이디와 인증요청의 멤버 아이디가 다른 경우 예외처리
-//        if(!memberService.findVerifiedMember(tokenMeberId).getRoles().contains(Roles.ADMIN.getRole()) &&
-//                !certification.getMember().getId().equals(tokenMeberId)){
-//            throw new BusinessLogicException(ExceptionCode.MEMBER_NO_PERMISSION);
-//        }
+        //어드민이 아니고 토큰 멤버 아이디와 인증요청의 멤버 아이디가 다른 경우 예외처리
+        if(!memberService.findVerifiedMember(tokenMeberId).getRoles().contains(Roles.ADMIN.getRole()) &&
+                !certification.getMember().getId().equals(tokenMeberId)){
+            throw new BusinessLogicException(ExceptionCode.MEMBER_NO_PERMISSION);
+        }
 
         CertificationDto.Response response = certificationMapper.certificationToResponse(certification);
-        return response;
+        return certification;
     }
 
     @Override
@@ -95,8 +93,6 @@ public class CertificationServiceImpl implements CertificationService{
     public CertificationDto.Response patchCertification(Certification certification, Long certificatedId, Long memberId) {
            Certification findVerifiedCertification = findVerifiedCertification(certificatedId);
            findVerifiedCertification.setCertificationStatus(certification.getCertificationStatus());
- //           Certification updatedCerti = beanUtils.copyNonNullProperties(certification, findVerifiedCertification);
-//            updatedCerti.setMember(memberService.findVerifiedMember(memberId));
             CertificationDto.Response response = certificationMapper.certificationToResponse(findVerifiedCertification);
             response.setMessage("퍼포머 인증이 수정됐습니다.");
 
@@ -104,7 +100,7 @@ public class CertificationServiceImpl implements CertificationService{
     }
 
 
-    private Certification findVerifiedCertification(Long certificationId) {
+    public Certification findVerifiedCertification(Long certificationId) {
 
         return certificationRepository.findById(certificationId).orElseThrow(
                 () -> new BusinessLogicException(ExceptionCode.CERTIFICATION_NOT_FOUND));

--- a/server/src/test/java/codestates/frogroup/indiego/domain/admin/CertificationServiceImplTest.java
+++ b/server/src/test/java/codestates/frogroup/indiego/domain/admin/CertificationServiceImplTest.java
@@ -111,7 +111,7 @@ class CertificationServiceImplTest {
         when(certificationMapper.certificationToResponse(certification)).thenReturn(expectedResponse);
 
         // when
-        CertificationDto.Response actualResponse = certificationService.findCertification(certification.getId(), 1L);
+        CertificationDto.Response actualResponse = certificationMapper.certificationToResponse(certificationService.findCertification(certification.getId(), 1L));
 
 
         assertThat(actualResponse).isEqualTo(expectedResponse);


### PR DESCRIPTION
## 유의해서 봐야할 커밋
- 어드민 로직 수정
## 배경
- AdminServiceImple 에서 CertificationServiceImpl.class 의 메서드를 사용할 때 ResponseDto가 아닌 엔티티를 반환하도록 변경했습니다. 
- 기존에는 AdminServiecImpe에서  CertificationServiceImpl.class 의  PatchCertification 메서드를 사용했는데,
AdminServiecImpe 에 PatchCertification() 를 작성했습니다.