### PR TITLE
[Feat -> Dev/fe] 퍼포머 인증에 따른 헤더 레이아웃 변경

### DIFF
--- a/client/src/Components/Header.jsx
+++ b/client/src/Components/Header.jsx
@@ -368,9 +368,9 @@ export default function Header() {
     const headers = {
       "Content-Type": "application/json",
       // eslint-disable-next-line prettier/prettier
-      "Authorization": `Bearer ${accessToken}`,
+      Authorization: `Bearer ${accessToken}`,
       // eslint-disable-next-line prettier/prettier
-      "Refresh": refreshToken,
+      Refresh: refreshToken,
     };
 
     return axios
@@ -422,20 +422,17 @@ export default function Header() {
               ? "current"
               : ""
           }
-          to="tickets"
-        >
+          to="tickets">
           티켓팅
         </Link>
         <Link
           className={location.pathname.includes("board") ? "current" : ""}
-          to="board/free?category=자유게시판&status=최신순&page=1&size=10"
-        >
+          to="board/free?category=자유게시판&status=최신순&page=1&size=10">
           커뮤니티
         </Link>
         <Link
           className={location.pathname.includes("search") ? "current" : ""}
-          to="search"
-        >
+          to="search">
           공연찾기
         </Link>
         {isLogin && (
@@ -443,18 +440,16 @@ export default function Header() {
             className={location.pathname.includes("user") ? "current" : ""}
             to={`/mypage/${
               userInfo?.role.toLowerCase() !== "user" ? "performer" : "user"
-            }/${userInfo?.id}`}
-          >
+            }/${userInfo?.id}`}>
             마이페이지
           </Link>
         )}
-        {isLogin && userInfo?.role.includes("PERFORMER") && (
+        {isLogin && userInfo?.role === "PERFORMER" && (
           <Link
             className={
               location.pathname.includes("tickets/create") ? "current" : ""
             }
-            to={"/tickets/create"}
-          >
+            to={"/tickets/create"}>
             공연작성하기
           </Link>
         )}
@@ -464,8 +459,7 @@ export default function Header() {
           <Link
             to={`/mypage/${
               userInfo?.role.toLowerCase() !== "user" ? "performer" : "user"
-            }/${userInfo?.id}`}
-          >
+            }/${userInfo?.id}`}>
             <div className="userInfo">
               <p className="welcome">환영합니다!</p>
               <p className="username">
@@ -491,15 +485,13 @@ export default function Header() {
       <NavbarIcon
         onClick={() => {
           setNavOpen(true);
-        }}
-      >
+        }}>
         <svg
           width="18"
           height="18"
           viewBox="0 0 18 18"
           fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+          xmlns="http://www.w3.org/2000/svg">
           <path d="M2 3H16V5H2V3Z" fill="black" />
           <path d="M2 8H16V10H2V8Z" fill="black" />
           <path d="M16 13H2V15H16V13Z" fill="black" />
@@ -516,8 +508,7 @@ export default function Header() {
                       userInfo?.role.toLowerCase() !== "user"
                         ? "performer"
                         : "user"
-                    }/${userInfo.id}`}
-                  >
+                    }/${userInfo.id}`}>
                     <h2>
                       {`${userInfo?.profile[0].nickname} 님,`}
                       <span>환영합니다!</span>
@@ -540,22 +531,19 @@ export default function Header() {
                 className={
                   location.pathname.includes("tickets") ? "current" : ""
                 }
-                to="/tickets"
-              >
+                to="/tickets">
                 티켓팅
               </Link>
               <Link
                 className={location.pathname.includes("board") ? "current" : ""}
-                to="board/free?category=자유게시판&status=최신순&page=1&size=10"
-              >
+                to="board/free?category=자유게시판&status=최신순&page=1&size=10">
                 커뮤니티
               </Link>
               <Link
                 className={
                   location.pathname.includes("search") ? "current" : ""
                 }
-                to="search"
-              >
+                to="search">
                 공연찾기
               </Link>
               {userInfo && (
@@ -567,8 +555,7 @@ export default function Header() {
                     userInfo?.role.toLowerCase() !== "user"
                       ? "performer"
                       : "user"
-                  }/${userInfo?.id}`}
-                >
+                  }/${userInfo?.id}`}>
                   마이페이지
                 </Link>
               )}
@@ -580,8 +567,7 @@ export default function Header() {
                         ? "current"
                         : ""
                     }
-                    to={"/tickets/create"}
-                  >
+                    to={"/tickets/create"}>
                     공연작성하기
                   </Link>
                 ))}


### PR DESCRIPTION
### [도입배경] 
퍼포머 인증절차 도입에 따라, 헤더를 통한 공연작성 페이지 진입을 분리해야할 필요 발생

### [수정사항]
인증된 퍼포머 즉 role === "PERFORMER" 일 경우에만 헤더를 통해 공연작성 페이지로 진입하도록 헤더 레이아웃 변경